### PR TITLE
Updated DETR inference method call with mask_pred argument

### DIFF
--- a/src/probabilistic_modeling/probabilistic_detr.py
+++ b/src/probabilistic_modeling/probabilistic_detr.py
@@ -133,7 +133,8 @@ class ProbabilisticDetr(META_ARCH_REGISTRY.get('Detr')):
         else:
             box_cls = output["pred_logits"]
             box_pred = output["pred_boxes"]
-            results = self.inference(box_cls, box_pred, images.image_sizes)
+            mask_pred = output["pred_masks"] if self.mask_on else None
+            results = self.inference(box_cls, box_pred, mask_pred, images.image_sizes)
             processed_results = []
             for results_per_image, input_per_image, image_size in zip(
                     results, batched_inputs, images.image_sizes):


### PR DESCRIPTION
DETR repo updated the `inference` method to 4 positional arguments instead of 3: https://github.com/facebookresearch/detr/commit/d45a12c72fd9877f896aad566eee8478e49cac95#diff-18a427cf4edd97ffaf7417aaf3a86879d3b1a2caf0642fe04007f97108307a0cL170-R193. Updating method call in probabilistic DETR with the `mask_pred` argument.